### PR TITLE
Fixed buildscript and made treasure status configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        maven { url = "https://maven.minecraftforge.net" }
+        mavenCentral()
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:4.+'
     }
 }
-apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'net.minecraftforge.gradle'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
@@ -15,22 +15,48 @@ version = "2.3.4"
 group = "atm.bloodworkxgaming.oeintegration" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "oeintegration"
 
-sourceCompatibility = targetCompatibility = "1.8" // Need this here so eclipse task generates correctly.
-compileJava {
-    sourceCompatibility = targetCompatibility = "1.8"
-}
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 minecraft {
-    version = "1.12.2-14.23.4.2759"
-    runDir = "run"
-
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20180710"
+    mappings channel: 'snapshot', version: '20171003-1.12'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+    runs {
+        client {
+            workingDirectory project.file('run')
+
+            // Recommended logging data for a userdev environment
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+
+            // Recommended logging level for the console
+            property 'forge.logging.console.level', 'debug'
+        }
+
+        server {
+
+            // Recommended logging data for a userdev environment
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+
+            // Recommended logging level for the console
+            property 'forge.logging.console.level', 'debug'
+        }
+    }
+}
+
+dependencies {
+    // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
+    // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
+    // The userdev artifact is a special name and will get all sorts of transformations applied to it.
+    minecraft "net.minecraftforge:forge:1.12.2-14.23.5.2859"
+    implementation fg.deobf('io.sommers:packmode:1.12.2-1.2.0-SNAPSHOT.8')
+    implementation fg.deobf("mezz.jei:jei_1.12.2:4.9.1.175")
+    implementation fg.deobf("slimeknights.mantle:Mantle:1.12-1.3.2.25")
+    implementation fg.deobf("curse.maven:tconstruct-74072:2563033")
+    implementation fg.deobf("curse.maven:oreexcavation-250898:2897369")
 }
 
 
@@ -41,33 +67,10 @@ repositories {
     maven { // crt
         url "http://maven.blamejared.com"
     }
-}
-
-dependencies {
-    // deobfCompile ('CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.+') {exclude group: 'org.ow2.asm'}
-    deobfCompile ('io.sommers:packmode:1.12.2-1.2.0-SNAPSHOT.8')
-    deobfCompile "mezz.jei:jei_1.12.2:4.9.1.175"
-    deobfCompile "slimeknights.mantle:Mantle:1.12-1.3.2.25"
-    deobfCompile ("slimeknights:TConstruct:1.12.2-2.9.1.70") {
-        exclude group: 'mezz.jei'
-    }
-}
-
-processResources {
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
-
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-
-        // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
-    }
-
-    // copy everything else except the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
+    maven {
+        url "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-all.zip

--- a/src/main/java/atm/bloodworkxgaming/oeintegration/Enchantments/ExcavationEnchantment.java
+++ b/src/main/java/atm/bloodworkxgaming/oeintegration/Enchantments/ExcavationEnchantment.java
@@ -61,6 +61,6 @@ public class ExcavationEnchantment extends Enchantment {
 
     @Override
     public boolean isTreasureEnchantment() {
-        return false;
+        return MainConfig.isTreasureEnchantment;
     }
 }

--- a/src/main/java/atm/bloodworkxgaming/oeintegration/Enchantments/ExcavationEnchantment.java
+++ b/src/main/java/atm/bloodworkxgaming/oeintegration/Enchantments/ExcavationEnchantment.java
@@ -61,6 +61,6 @@ public class ExcavationEnchantment extends Enchantment {
 
     @Override
     public boolean isTreasureEnchantment() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/atm/bloodworkxgaming/oeintegration/MainConfig.java
+++ b/src/main/java/atm/bloodworkxgaming/oeintegration/MainConfig.java
@@ -55,6 +55,9 @@ public class MainConfig {
     @Config.Comment("The max level of enchantment needed to full power of the tool.")
     public static int maxEnchantmentLevel = 5;
 
+    @Config.Comment("true classifies the enchantment as a treasure enchantment")
+    public static boolean isTreasureEnchantment = true;
+
     @Mod.EventBusSubscriber
     static class ConfigurationHolder {
         @SubscribeEvent


### PR DESCRIPTION
Buildscript was completely inoperative. I can revert my changes to it if you'd like.

The primary goal here is to make the enchantment's treasure status in oeintegration configurable; Sevtech describes the enchantment as being attainable in an enchantment table, but the mod has it classed as a treasure enchantment. Hoping to poke Darkosto so they'll push an update to the pack.